### PR TITLE
Use Montserrat font sitewide

### DIFF
--- a/css/cv.css
+++ b/css/cv.css
@@ -13,7 +13,7 @@ header.main{
    text-align: left;
 }
 p {
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    font-size: 20px;
    font-weight: 300;
    text-align: justify;
@@ -52,7 +52,7 @@ p.job_desc{
 }
 
 h1{
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    font-size: 80px;
    color: black;
    text-decoration-line: underline;
@@ -62,7 +62,7 @@ h1{
    text-align: start;
 }
 h2,h3{
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    color: black;
    text-decoration-line: underline;
 }
@@ -72,7 +72,7 @@ div{
 	margin: 10px;
 }
 .abilities{
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    font-size:16px;
    text-align: left;
    padding: 20px;
@@ -89,7 +89,7 @@ ul{
    padding: 0;
 }
 li{
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    font-size: 20px;
    font-weight: 300;
    padding: 10px 20px;
@@ -99,7 +99,7 @@ li{
    margin: 10px 0px;
 }
 nav ul, footer ul {
-   font-family:'Helvetica', 'Arial', 'Sans-Serif';
+   font-family: "Montserrat", sans-serif;
    padding: 0px;
    list-style: none;
    font-weight: bold;

--- a/css/main.css
+++ b/css/main.css
@@ -7,7 +7,7 @@ body{
    margin: 30px auto;
 }
 nav ul, footer ul {
-   font-family:'Helvetica', 'Arial', 'Sans-Serif';
+   font-family: "Montserrat", sans-serif;
    padding: 0px;
    margin: 0px;
    list-style: none;
@@ -41,7 +41,7 @@ header.main{
    text-align: left;
 }
 h1{
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    font-size: 80px;
    color: white;
    background-color: #286da8;
@@ -55,12 +55,12 @@ h1.secundario{
    background-color: #b37d4e;
 }
 h2,h3{
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    color: black;
    text-decoration-line: underline;
 }
 p {
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    font-size: 20px;
    font-weight: 300;
    text-align: justify;
@@ -77,7 +77,7 @@ footer {
 }
 
 li{
-   font-family: "Garamond";
+   font-family: "Montserrat", sans-serif;
    font-size: 20px;
    font-weight: 300;
    text-align: center;


### PR DESCRIPTION
## Summary
- update the main stylesheet and CV stylesheet to use the Montserrat font

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6844518a6f2883218366d827602bad6b