### PR TITLE
Align index layout with CV style

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
 		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
   
 	</head>
-	<body>
+        <body{% if body_class %} class="{{ body_class }}"{% endif %}>
 		<nav class="my-3 border-0">
 			<ul class="nav flex-row gap-2 list-unstyled">
 			  <li class="nav-item">

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,53 +1,27 @@
 {% extends "default.html" %}
 {% block content %}
-<!DOCTYPE HTML>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>What I'm working on</title>
-    <!-- link to main stylesheet -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
-</head>
-<body>
-    <div class="featured">
-        <h1 class="principal">Covid en la Argentina</h1> 
-        <h2> En ShinyApps conjuntamente con el paquete leaflet </h2> 
-        <p>ShinyApp de los casos confirmados en la Argentina, Hospitalizados y fallecidos segun la provincia.</p>
-        <img src="https://user-images.githubusercontent.com/48648720/88417742-d46fe180-cdb8-11ea-94ba-991daddf361f.PNG">
-        <br>
-        <a class ="app" href= "https://simonblasco.shinyapps.io/covid-ar/">App covid-ar</a>
+<header class="my-4">
+  <h1 class="display-3 text-white">Covid en la Argentina</h1>
+  <p class="lead text-white">
+    ShinyApp de los casos confirmados en la Argentina, Hospitalizados y fallecidos segun la provincia.
+  </p>
+</header>
+<div class="container-fluid">
+  <div class="row g-4 mb-4">
+    <div class="col-md-6">
+      <img src="https://user-images.githubusercontent.com/48648720/88417742-d46fe180-cdb8-11ea-94ba-991daddf361f.PNG" class="img-fluid" alt="covid-ar" />
     </div>
-    <p class="lead-text-center">"aslas"</p>
+    <div class="col-md-6 d-flex align-items-center">
+      <a class="btn btn-light" href="https://simonblasco.shinyapps.io/covid-ar/">App covid-ar</a>
     </div>
-    <div class="featured">
-        <h1 class="secundario">Tableau jugadores FIFA20</h1>
-        <h2> En Tableau Public</h2> 
-        <img src="https://user-images.githubusercontent.com/48648720/89839988-73306800-db45-11ea-85ae-bd17608cb7d4.png">
-        <br>
-        <a class ="app" href= "https://simonblasco.shinyapps.io/covid-ar/">Tableau Public</a>
+  </div>
+  <div class="row g-4">
+    <div class="col-md-6">
+      <img src="https://user-images.githubusercontent.com/48648720/89839988-73306800-db45-11ea-85ae-bd17608cb7d4.png" class="img-fluid" alt="tableau-fifa20" />
     </div>
-    <div class= "featured">
-        <h1 class="principal">Covid en la Argentina</h1> 
-        <h2> En ShinyApps conjuntamente con el paquete leaflet </h2> 
-        <p>ShinyApp de los casos confirmados en la Argentina, Hospitalizados y fallecidos segun la provincia.</p>
-        <img src="https://user-images.githubusercontent.com/48648720/88417742-d46fe180-cdb8-11ea-94ba-991daddf361f.PNG">
-        <br>
-        <a class ="app" href= "https://simonblasco.shinyapps.io/covid-ar/">App covid-ar</a>
-<p class="lead-text-center">"aslas"</p>
-
-<div class="featured">
-    <h1 class="secundario">Tableau jugadores FIFA20</h1>
-    <h2> En Tableau Public</h2> 
-    <img src="https://user-images.githubusercontent.com/48648720/89839988-73306800-db45-11ea-85ae-bd17608cb7d4.png">
-    <br>
-    <a class ="app" href= "https://simonblasco.shinyapps.io/covid-ar/">Tableau Public</a>
+    <div class="col-md-6 d-flex align-items-center">
+      <a class="btn btn-light" href="https://simonblasco.shinyapps.io/covid-ar/">Tableau Public</a>
+    </div>
+  </div>
 </div>
-<div class= "featured">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO" crossorigin="anonymous"></script>
-              
-</body>
 {% endblock %}
-</div>
-</html>
-

--- a/render.py
+++ b/render.py
@@ -6,7 +6,7 @@ env = Environment(loader=FileSystemLoader("_layouts"))
 
 # pages to render
 pages = [
-    ("index.html", {"title": "main structure"}),
+    ("index.html", {"title": "main structure", "body_class": "bg-dark"}),
     ("cv.html", {"title": "main structure"}),
 ]
 


### PR DESCRIPTION
## Summary
- allow passing an optional body class in the default layout
- restyle the index template using Bootstrap grid and dark theme
- render index with a `bg-dark` body class via `render.py`

## Testing
- `python render.py` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_684f782492dc8321a229993c3d32c683